### PR TITLE
Fixed 3 issues of type: PYTHON_E231 throughout 2 files in repo.

### DIFF
--- a/rbflayer.py
+++ b/rbflayer.py
@@ -18,7 +18,7 @@ class InitCentersRandom(Initializer):
     def __call__(self, shape, dtype=None):
         assert shape[1] == self.X.shape[1]
         idx = np.random.randint(self.X.shape[0], size=shape[0])
-        return self.X[idx,:]
+        return self.X[idx, :]
 
         
 class RBFLayer(Layer):

--- a/test.py
+++ b/test.py
@@ -40,8 +40,8 @@ if __name__ == "__main__":
     
     plt.plot(X, y_pred)
     plt.plot(X, y)
-    plt.plot([-1,1], [0,0], color='black')
-    plt.xlim([-1,1])
+    plt.plot([-1, 1], [0, 0], color='black')
+    plt.xlim([-1, 1])
     
     centers = rbflayer.get_weights()[0]
     widths = rbflayer.get_weights()[1]


### PR DESCRIPTION
PYTHON_E231: 'missing whitespace after ‘,’, ‘;’, or ‘:’'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.